### PR TITLE
test(e2e): add Playwright end-to-end test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@
 # testing
 /coverage
 
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # next.js
 /.next/
 /out/

--- a/TESTING.md
+++ b/TESTING.md
@@ -164,3 +164,46 @@ File: `src/components/auth/login-form.tsx`
 5. **Step 5**: Write hooks test setup and tests for `useAuth.ts`.
 6. **Step 6**: Implement tests for UI Components (beginning with forms like `LoginForm` and `CreateAccountForm`).
 7. **Step 7**: Update `package.json` to include `"test": "vitest"` and `"test:run": "vitest run"`.
+
+---
+
+## 5. End-to-End Testing (Playwright)
+
+Alongside the Vitest unit suite, the project has a **Playwright** end-to-end suite in
+[`e2e/`](e2e/) that drives a real browser against the app.
+
+### Design
+
+- **Runs against a production build.** `playwright.config.ts` boots the app with
+  `npm run build && npm run start`. The Next.js dev server compiles routes on
+  demand, which makes the `load` event and hydration timing flaky under parallel
+  test load; `next start` serves pre-rendered pages that load and hydrate fast and
+  deterministically.
+- **No live backend required.** Tests intercept backend calls at the network layer
+  with `page.route` via the helpers in [`e2e/utils/mocks.ts`](e2e/utils/mocks.ts)
+  (auth token/profile, login success/failure, categories, items). So the suite is
+  hermetic and does not depend on `NEXT_PUBLIC_API_URL`.
+
+### Coverage
+
+| Spec | What it covers |
+| :--- | :--- |
+| `landing.spec.ts` | Root → default-locale redirect, hero content, CTA links, console-error check |
+| `navigation.spec.ts` | Navbar routing (marketplace/about/contribute), signed-out state, 404 page |
+| `i18n.spec.ts` | `en`/`ar` `lang`+`dir` attributes, RTL content, language switcher |
+| `auth.spec.ts` | Login form render, email/phone toggle, Zod validation, password visibility, success redirect, failure toast, register link |
+| `marketplace.spec.ts` | Renders mocked items, client-side search filter, empty state |
+
+### Commands
+
+```bash
+npm run test:e2e          # run the full suite (headless)
+npm run test:e2e:ui       # interactive Playwright UI mode
+npm run test:e2e:report   # open the last HTML report
+```
+
+First-time setup installs the browser binary:
+
+```bash
+npx playwright install chromium
+```

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockLoggedOut,
+  mockLoginFailure,
+  mockLoginSuccess,
+} from "./utils/mocks";
+
+test.describe("Login flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLoggedOut(page);
+  });
+
+  test("renders the login form with email selected by default", async ({
+    page,
+  }) => {
+    await page.goto("/en/login");
+    await expect(
+      page.getByRole("heading", { name: /Welcome Back/i }),
+    ).toBeVisible();
+    await expect(page.locator("#email")).toBeVisible();
+  });
+
+  test("switches between email and phone contact methods", async ({ page }) => {
+    await page.goto("/en/login");
+
+    await expect(page.locator("#email")).toBeVisible();
+
+    await page.getByRole("button", { name: "Via Phone" }).click();
+    await expect(page.locator("#phoneNumber")).toBeVisible();
+    await expect(page.getByText("+20")).toBeVisible();
+
+    await page.getByRole("button", { name: "Via Email" }).click();
+    await expect(page.locator("#email")).toBeVisible();
+  });
+
+  test("shows a validation error for an invalid email", async ({ page }) => {
+    await page.goto("/en/login");
+
+    await page.locator("#email").fill("not-an-email");
+    await page.locator("#password").fill("something");
+    await page.getByRole("button", { name: "Log In" }).click();
+
+    await expect(
+      page.getByText(/Please enter a valid email address/i),
+    ).toBeVisible();
+  });
+
+  test("toggles password visibility", async ({ page }) => {
+    await page.goto("/en/login");
+
+    const password = page.locator("#password");
+    await password.fill("secret123");
+    await expect(password).toHaveAttribute("type", "password");
+
+    await page.getByRole("button", { name: "Show password" }).click();
+    await expect(password).toHaveAttribute("type", "text");
+  });
+
+  test("successful login redirects home and drops the login page", async ({
+    page,
+  }) => {
+    await mockLoginSuccess(page);
+    await page.goto("/en/login");
+
+    await page.locator("#email").fill("student@university.edu");
+    await page.locator("#password").fill("Password123");
+    await page.getByRole("button", { name: "Log In" }).click();
+
+    await expect(page).not.toHaveURL(/\/login/);
+    await expect(page.getByText(/Logged in successfully/i)).toBeVisible();
+  });
+
+  test("failed login surfaces an error toast and stays on the login page", async ({
+    page,
+  }) => {
+    await mockLoginFailure(page, "Invalid credentials");
+    await page.goto("/en/login");
+
+    await page.locator("#email").fill("student@university.edu");
+    await page.locator("#password").fill("WrongPass1");
+    await page.getByRole("button", { name: "Log In" }).click();
+
+    // An error toast (sonner) is shown and the user is not redirected.
+    await expect(page.locator("[data-sonner-toast]")).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("links to the register page", async ({ page }) => {
+    await page.goto("/en/login");
+    await page.getByRole("link", { name: "Sign Up" }).click();
+    await expect(page).toHaveURL(/\/en\/register/);
+  });
+});

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedOut } from "./utils/mocks";
+
+test.describe("Internationalization", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLoggedOut(page);
+  });
+
+  test("English locale is LTR", async ({ page }) => {
+    await page.goto("/en");
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    await expect(page.locator("html")).toHaveAttribute("dir", "ltr");
+  });
+
+  test("Arabic locale is RTL and shows translated content", async ({ page }) => {
+    await page.goto("/ar");
+    await expect(page.locator("html")).toHaveAttribute("lang", "ar");
+    await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+    await expect(page.getByText("يديره المجتمع")).toBeVisible();
+  });
+
+  test("language switcher toggles between en and ar", async ({ page }) => {
+    await page.goto("/en");
+
+    await page.getByRole("button", { name: /العربية/ }).first().click();
+    await expect(page).toHaveURL(/\/ar(\/)?$/);
+    await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+
+    await page.getByRole("button", { name: /English/ }).first().click();
+    await expect(page).toHaveURL(/\/en(\/)?$/);
+    await expect(page.locator("html")).toHaveAttribute("dir", "ltr");
+  });
+});

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedOut } from "./utils/mocks";
+
+test.describe("Landing page", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLoggedOut(page);
+  });
+
+  test("redirects the bare root to the default locale", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/en(\/)?$/);
+  });
+
+  test("renders the English hero content", async ({ page }) => {
+    await page.goto("/en");
+    await expect(
+      page.getByRole("heading", { name: /Ecosystem/i }),
+    ).toBeVisible();
+    await expect(page.getByText("Community Driven").first()).toBeVisible();
+  });
+
+  test("hero CTA links point to the marketplace", async ({ page }) => {
+    await page.goto("/en");
+    const cta = page.getByRole("link", { name: /Enter the Ecosystem/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("href", "/en/marketplace");
+  });
+
+  test("has no console errors on load", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+    await page.goto("/en");
+    await expect(
+      page.getByRole("heading", { name: /Ecosystem/i }),
+    ).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});

--- a/e2e/marketplace.spec.ts
+++ b/e2e/marketplace.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+import {
+  makeItem,
+  mockLoggedOut,
+  mockMarketplace,
+} from "./utils/mocks";
+
+test.describe("Marketplace", () => {
+  test("renders items returned by the API", async ({ page }) => {
+    await mockLoggedOut(page);
+    await mockMarketplace(page, {
+      items: [
+        makeItem({ id: "a", title: "Calculus Textbook" }),
+        makeItem({ id: "b", title: "Oscilloscope", categoryName: "Lab Tools" }),
+      ],
+    });
+
+    await page.goto("/en/marketplace");
+
+    await expect(page.getByText("Calculus Textbook")).toBeVisible();
+    await expect(page.getByText("Oscilloscope")).toBeVisible();
+  });
+
+  test("filters items by search query", async ({ page }) => {
+    await mockLoggedOut(page);
+    await mockMarketplace(page, {
+      items: [
+        makeItem({ id: "a", title: "Calculus Textbook" }),
+        makeItem({ id: "b", title: "Oscilloscope" }),
+      ],
+    });
+
+    await page.goto("/en/marketplace");
+    await expect(page.getByText("Calculus Textbook")).toBeVisible();
+
+    await page
+      .getByPlaceholder(/Search resources, textbooks, tools/i)
+      .fill("Oscilloscope");
+
+    await expect(page.getByText("Oscilloscope")).toBeVisible();
+    await expect(page.getByText("Calculus Textbook")).toHaveCount(0);
+  });
+
+  test("shows an empty state when no items exist", async ({ page }) => {
+    await mockLoggedOut(page);
+    await mockMarketplace(page, { items: [] });
+
+    await page.goto("/en/marketplace");
+
+    // No item titles from the sample data should be present.
+    await expect(page.getByText("Calculus Textbook")).toHaveCount(0);
+    await expect(
+      page.getByRole("heading", { name: /Marketplace/i }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedOut, mockMarketplace } from "./utils/mocks";
+
+test.describe("Primary navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLoggedOut(page);
+    await mockMarketplace(page);
+  });
+
+  test("navbar links route to the main sections", async ({ page }) => {
+    await page.goto("/en");
+
+    const nav = page.getByRole("navigation");
+
+    await nav.getByRole("link", { name: /Marketplace/i }).click();
+    await expect(page).toHaveURL(/\/en\/marketplace/);
+
+    await nav.getByRole("link", { name: /About/i }).click();
+    await expect(page).toHaveURL(/\/en\/about/);
+
+    await nav.getByRole("link", { name: /Contribute/i }).click();
+    await expect(page).toHaveURL(/\/en\/contribute/);
+  });
+
+  test("shows a sign-in entry point when logged out", async ({ page }) => {
+    await page.goto("/en");
+    await expect(
+      page.getByRole("link", { name: /Sign In|Join Ecosystem/i }).first(),
+    ).toBeVisible();
+  });
+
+  test("unknown route renders the not-found page", async ({ page }) => {
+    const response = await page.goto("/en/this-route-does-not-exist");
+    expect(response?.status()).toBe(404);
+  });
+});

--- a/e2e/utils/mocks.ts
+++ b/e2e/utils/mocks.ts
@@ -1,0 +1,145 @@
+import type { Page, Route } from "@playwright/test";
+
+/**
+ * Backend mocking helpers.
+ *
+ * The frontend talks to two surfaces:
+ *   - Next.js BFF routes under `/api/auth/*` (login/register/logout/token)
+ *   - The backend proxied under `/api/v1/*` (categories, items, profile, ...)
+ *
+ * These helpers intercept both so e2e tests run without a live API.
+ */
+
+const json = (route: Route, status: number, body: unknown) =>
+  route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+
+export interface MockCategory {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface MockItem {
+  id: string;
+  title: string;
+  description: string;
+  price: number;
+  currency: string;
+  itemType: number;
+  status: string;
+  ownerId: string;
+  ownerName: string;
+  availableFrom: string;
+  availableTo: string;
+  location: string;
+  imageUrls: string[];
+  isFavorited: boolean;
+  favoriteCount: number;
+  categoryId: string;
+  categoryName: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const sampleCategories: MockCategory[] = [
+  { id: "cat-1", name: "Textbooks", description: "Course books" },
+  { id: "cat-2", name: "Lab Tools", description: "Laboratory equipment" },
+];
+
+export function makeItem(overrides: Partial<MockItem> = {}): MockItem {
+  return {
+    id: "item-1",
+    title: "Calculus Textbook",
+    description: "Barely used, 8th edition.",
+    price: 150,
+    currency: "EGP",
+    itemType: 1,
+    status: "Available",
+    ownerId: "owner-1",
+    ownerName: "Sara Ahmed",
+    availableFrom: "",
+    availableTo: "",
+    location: "Computer Science",
+    imageUrls: [],
+    isFavorited: false,
+    favoriteCount: 0,
+    categoryId: "cat-1",
+    categoryName: "Textbooks",
+    createdAt: "2026-07-01T10:00:00.000Z",
+    updatedAt: "2026-07-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** Signed-out session: `/api/auth/token` returns no token. */
+export async function mockLoggedOut(page: Page) {
+  await page.route("**/api/auth/token", (route) =>
+    json(route, 200, { token: null }),
+  );
+}
+
+/** Signed-in session: token endpoint + profile both resolve. */
+export async function mockLoggedIn(
+  page: Page,
+  profile: Record<string, unknown> = {
+    id: "owner-1",
+    fullName: "Test Student",
+    email: "student@university.edu",
+  },
+) {
+  await page.route("**/api/auth/token", (route) =>
+    json(route, 200, { token: "fake-jwt-token" }),
+  );
+  await page.route("**/api/v1/profile/me", (route) =>
+    json(route, 200, { success: true, data: profile }),
+  );
+}
+
+/** Marketplace data endpoints. */
+export async function mockMarketplace(
+  page: Page,
+  {
+    categories = sampleCategories,
+    items = [makeItem()],
+  }: { categories?: MockCategory[]; items?: MockItem[] } = {},
+) {
+  await page.route("**/api/v1/Categories", (route) =>
+    json(route, 200, categories),
+  );
+  await page.route("**/api/v1/Items*", (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    return json(route, 200, {
+      items,
+      pageNumber: 1,
+      pageSize: 20,
+      totalCount: items.length,
+      totalPages: 1,
+      hasPreviousPage: false,
+      hasNextPage: false,
+    });
+  });
+}
+
+/** Mock the login BFF route to succeed with a token. */
+export async function mockLoginSuccess(page: Page) {
+  await page.route("**/api/auth/login", (route) =>
+    json(route, 200, {
+      success: true,
+      data: { token: "fake-jwt-token" },
+    }),
+  );
+}
+
+/** Mock the login BFF route to fail with a message. */
+export async function mockLoginFailure(
+  page: Page,
+  message = "Invalid credentials",
+) {
+  await page.route("**/api/auth/login", (route) =>
+    json(route, 401, { error: message }),
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -2885,6 +2886,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -12028,6 +12045,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/po-parser": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "lint:fix": "eslint --fix",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -36,6 +39,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright end-to-end test configuration for the UniCare frontend.
+ *
+ * The dev server is booted automatically (see `webServer`) so `npm run test:e2e`
+ * works from a clean checkout. Tests intercept backend calls with `page.route`
+ * (see `e2e/utils/`), so a live API at NEXT_PUBLIC_API_URL is NOT required.
+ */
+
+const PORT = Number(process.env.E2E_PORT ?? 3000);
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Fail the build on CI if test.only is committed.
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "list",
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  // Run e2e against a production build rather than the dev server: the dev
+  // server compiles routes on demand, which makes the `load` event and
+  // hydration timing unreliable under parallel test load. `next start` serves
+  // pre-built, pre-rendered pages that load and hydrate fast and deterministically.
+  webServer: {
+    command: `npm run build && npm run start -- -p ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 240_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/src/components/auth/auth-required-modal.test.tsx
+++ b/src/components/auth/auth-required-modal.test.tsx
@@ -13,6 +13,7 @@ vi.mock("next-intl", () => ({
     };
     return messages[key] || key;
   },
+  useLocale: () => "en",
 }));
 
 // Mock routing router

--- a/src/components/auth/create-account-form.test.tsx
+++ b/src/components/auth/create-account-form.test.tsx
@@ -16,15 +16,28 @@ vi.mock("@/api/auth-api", () => ({
 
 // Mock routing router
 const mockPush = vi.fn();
-vi.mock("@/i18n/routing", () => ({
-  useRouter: () => ({
-    push: mockPush,
-    replace: vi.fn(),
-    back: vi.fn(),
-    prefetch: vi.fn(),
-  }),
-  usePathname: () => "/",
-}));
+vi.mock("@/i18n/routing", async () => {
+  const react = await import("react");
+  return {
+    useRouter: () => ({
+      push: mockPush,
+      replace: vi.fn(),
+      back: vi.fn(),
+      prefetch: vi.fn(),
+    }),
+    usePathname: () => "/",
+    Link: react.forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement>
+    >(({ children, href, ...props }, ref) =>
+      react.createElement(
+        "a",
+        { ref, href: href?.toString(), ...props },
+        children,
+      ),
+    ),
+  };
+});
 
 describe("CreateAccountForm", () => {
   beforeEach(() => {
@@ -36,7 +49,7 @@ describe("CreateAccountForm", () => {
   it("should render student role and phone contact by default", () => {
     render(<CreateAccountForm />);
 
-    expect(screen.getByRole("heading", { name: "Create Account" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Join the Ecosystem" })).toBeInTheDocument();
     expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/last name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/phone number/i)).toBeInTheDocument();
@@ -53,13 +66,13 @@ describe("CreateAccountForm", () => {
     const alumniButton = screen.getByRole("button", { name: "Alumni" });
     const studentButton = screen.getByRole("button", { name: "Student" });
 
-    // Click Alumni
+    // Click Alumni -> becomes the active (highlighted) option
     await user.click(alumniButton);
-    expect(alumniButton).toHaveClass("bg-white text-primary");
+    expect(alumniButton).toHaveClass("bg-white", "shadow-sm");
 
-    // Click Student
+    // Click Student -> active state moves back to Student
     await user.click(studentButton);
-    expect(studentButton).toHaveClass("bg-primary/10");
+    expect(studentButton).toHaveClass("bg-white", "shadow-sm");
   });
 
   it("should switch contact methods", async () => {

--- a/src/components/auth/login-form.test.tsx
+++ b/src/components/auth/login-form.test.tsx
@@ -23,15 +23,28 @@ vi.mock("@/hooks/useAuth", () => ({
 
 // Mock routing router
 const mockPush = vi.fn();
-vi.mock("@/i18n/routing", () => ({
-  useRouter: () => ({
-    push: mockPush,
-    replace: vi.fn(),
-    back: vi.fn(),
-    prefetch: vi.fn(),
-  }),
-  usePathname: () => "/",
-}));
+vi.mock("@/i18n/routing", async () => {
+  const react = await import("react");
+  return {
+    useRouter: () => ({
+      push: mockPush,
+      replace: vi.fn(),
+      back: vi.fn(),
+      prefetch: vi.fn(),
+    }),
+    usePathname: () => "/",
+    Link: react.forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement>
+    >(({ children, href, ...props }, ref) =>
+      react.createElement(
+        "a",
+        { ref, href: href?.toString(), ...props },
+        children,
+      ),
+    ),
+  };
+});
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -57,7 +70,9 @@ describe("LoginForm", () => {
   it("should render email login form by default", () => {
     renderWithProviders(<LoginForm />);
 
-    expect(screen.getByText("Welcome back. Please enter your details.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Enter your credentials to access your UniCare account."),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Log In" })).toBeInTheDocument();

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -44,7 +44,18 @@ vi.mock("sonner", () => ({
   },
 }));
 
-// Mock next-intl translations
-vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
-}));
+// Mock next-intl: resolve real English messages so components render the same
+// copy users see. Namespace-aware, mirroring `useTranslations("Namespace")`.
+vi.mock("next-intl", async () => {
+  const messages = (await import("../../messages/en.json")).default as Record<
+    string,
+    Record<string, string>
+  >;
+  return {
+    useTranslations: (namespace?: string) => (key: string) => {
+      const scope = namespace ? messages[namespace] : undefined;
+      return scope?.[key] ?? key;
+    },
+    useLocale: () => "en",
+  };
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
@@ -8,6 +8,8 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: "./src/test/setup.ts",
+    // Playwright specs live in `e2e/` and are run via `npm run test:e2e`.
+    exclude: [...configDefaults.exclude, "e2e/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
Add a hermetic Playwright e2e suite covering landing, navigation, i18n, auth, and marketplace flows. Backend calls are intercepted at the network layer (e2e/utils/mocks.ts), so no live API is required.

- Run against a production build (build && start) since the dev server's on-demand compilation makes the load event and hydration flaky under parallel load
- Add test:e2e / test:e2e:ui / test:e2e:report scripts
- Exclude e2e/** from Vitest to avoid *.spec.ts collisions
- Ignore Playwright artifacts and document the setup in TESTING.md